### PR TITLE
Add sample kickstart-quickstart.json to bypass the setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Demonstrates adding multiple tenants.
 
 *kickstart-quickstart.json*
 
-Used for example guides to by the setup wizard and quickly spin up an instance with an API key, application configuration, admin and sample user.
+Used in example guides to bypass the setup wizard and quickly spin up a FusionAuth instance with an API key, application configuration, admin and sample user.
 
 ### Example Apps
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [Kickstart Documentation](https://fusionauth.io/docs/v1/tech/installation-gu
 |  |- kickstart-development.json
 |  |- kickstart-kitchen-sink.json
 |  |- kickstart-multipleTenants.json
+|  |- kickstart-quickstart.json
 ```
 
 ### Kickstart Examples
@@ -36,6 +37,10 @@ Shows an example of a bit of everything, including environment variables, UUID g
 *kickstart-multiple-tenants.json*
 
 Demonstrates adding multiple tenants.
+
+*kickstart-quickstart.json*
+
+Used for example guides to by the setup wizard and quickly spin up an instance with an API key, application configuration, admin and sample user.
 
 ### Example Apps
 

--- a/fusionauth/kickstart-quickstart.json
+++ b/fusionauth/kickstart-quickstart.json
@@ -1,0 +1,109 @@
+{
+  "variables": {
+    "apiKey": "33052c8a-c283-4e96-9d2a-eb1215c69f8f-not-for-prod",
+    "asymmetricKeyId": "#{UUID()}",
+    "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
+    "clientSecret": "super-secret-secret-that-should-be-regenerated-for-production",
+    "defaultTenantId": "d7d09513-a3f5-401c-9685-34ab6c552453",
+    "adminEmail": "admin@example.com",
+    "adminPassword": "password",
+    "adminUserId": "00000000-0000-0000-0000-000000000001",
+    "userEmail": "richard@example.com",
+    "userPassword": "password",
+    "userUserId": "00000000-0000-0000-0000-111111111111"
+  },
+  "apiKeys": [
+    {
+      "key": "#{apiKey}",
+      "description": "Unrestricted API key"
+    }
+  ],
+  "requests": [
+    {
+      "method": "POST",
+      "url": "/api/key/generate/#{asymmetricKeyId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "key": {
+          "algorithm": "RS256",
+          "name": "For example app",
+          "length": 2048
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/application/#{applicationId}",
+      "tenantId": "#{defaultTenantId}",
+      "body": {
+        "application": {
+          "name": "Example App",
+          "oauthConfiguration": {
+            "authorizedRedirectURLs": [
+              "https://fusionauth.io"
+            ],
+            "logoutURL": "https://fusionauth.io",
+            "clientSecret": "#{clientSecret}",
+            "enabledGrants": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "generateRefreshTokens": true,
+            "requireRegistration": true
+          },
+          "jwtConfiguration": {
+            "enabled": true,
+            "accessTokenKeyId": "#{asymmetricKeyId}",
+            "idTokenKeyId": "#{asymmetricKeyId}"
+          }
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/#{adminUserId}",
+      "body": {
+        "registration": {
+          "applicationId": "#{FUSIONAUTH_APPLICATION_ID}",
+          "roles": [
+            "admin"
+          ]
+        },
+        "roles": [
+          "admin"
+        ],
+        "skipRegistrationVerification": true,
+        "user": {
+          "birthDate": "1981-06-04",
+          "data": {
+            "favoriteColor": "chartreuse"
+          },
+          "email": "#{adminEmail}",
+          "firstName": "Erlich",
+          "lastName": "Bachman",
+          "password": "#{adminPassword}",
+          "imageUrl": "//www.gravatar.com/avatar/5e7d99e498980b4759650d07fb0f44e2"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/#{userUserId}",
+      "body": {
+        "user": {
+          "birthDate": "1985-11-23",
+          "email": "#{userEmail}",
+          "firstName": "Richard",
+          "lastName": "Flintstone",
+          "password": "#{userPassword}"
+        },
+        "registration": {
+          "applicationId": "#{applicationId}",
+          "data": {
+            "favoriteColor": "turquoise"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Adds a sample `kickstart-quickstart.json` used in example guides to bypass the setup wizard and quickly spin up a FusionAuth instance with an API key, application configuration, admin and sample user.